### PR TITLE
fixed behavior in numberless footnotes

### DIFF
--- a/expex/epltxfn.sty~
+++ b/expex/epltxfn.sty~
@@ -13,7 +13,7 @@
    \everyfootnote
    \parindent=1em
    \noindent
-   \ifthenelse{\equal{\@thefnmark}{}}{#1}{\@thefnmark.\enspace{#1}}%
+   \@thefnmark.\enspace #1%
 }
 \def\allocglfns#1{\begingroup
    \XKV@for@n{#1}\which{%


### PR DESCRIPTION
Previously, if the footnote didn't have a number, a dot would be inserted nonetheless. Now numberless footnotes begin with the footnote text, with no dot inserted before it.